### PR TITLE
修复Promise.resolve()后调用then的Bug

### DIFF
--- a/src/com/dormouse/Promise.as
+++ b/src/com/dormouse/Promise.as
@@ -197,7 +197,7 @@ package com.dormouse
 			var parent:Promise = this;
 			var state:int = parent._state;
 			
-			if (state === FULFILLED && onFulfillment !== null || state === REJECTED && onRejection !== null) {
+			if (state === FULFILLED && onFulfillment == null || state === REJECTED && onRejection == null) {
 				return this;
 			}
 			


### PR DESCRIPTION
使用resolve方法构建的Promise对象，调用then，回调函数没有被执行。测试代码如下：
Promise.resolve("Test").then(function(result:*):void{
    trace(result);
});
trace没有被调用。

原版的这个地方的源码参照
https://github.com/jakearchibald/es6-promise/blob/master/lib/es6-promise/promise.js 366行
